### PR TITLE
Replace 'AddLabelText' with 'AddLabelRender' function

### DIFF
--- a/src/Option.js
+++ b/src/Option.js
@@ -3,7 +3,7 @@ var classes = require('classnames');
 
 var Option = React.createClass({
 	propTypes: {
-		addLabelText: React.PropTypes.string,          // string rendered in case of allowCreate option passed to ReactSelect
+		addLabelRender: React.PropTypes.func,          // string rendered in case of allowCreate option passed to ReactSelect
 		className: React.PropTypes.string,             // className (based on mouse position)
 		mouseDown: React.PropTypes.func,               // method to handle click on option element
 		mouseEnter: React.PropTypes.func,              // method to handle mouseEnter on option element
@@ -34,7 +34,7 @@ var Option = React.createClass({
 	},
 	render () {
 		var option = this.props.option;
-		var label = option.create ? this.props.addLabelText.replace('{label}', option.label) : this.props.renderFunc(option);
+		var label = option.create ? this.props.addLabelRender(option.label) : this.props.renderFunc(option);
 		var optionClasses = classes(this.props.className, option.className);
 
 		return option.disabled ? (

--- a/src/Select.js
+++ b/src/Select.js
@@ -17,7 +17,7 @@ var Select = React.createClass({
 	displayName: 'Select',
 
 	propTypes: {
-		addLabelText: React.PropTypes.string,      // placeholder displayed when you want to add a label on a multi-value input
+		addLabelRender: React.PropTypes.func,
 		allowCreate: React.PropTypes.bool,         // whether to allow creation of new entries
 		asyncOptions: React.PropTypes.func,        // function to call to get options
 		autoload: React.PropTypes.bool,            // whether to auto-load the default async options set
@@ -62,7 +62,7 @@ var Select = React.createClass({
 
 	getDefaultProps () {
 		return {
-			addLabelText: 'Add "{label}"?',
+			addLabelRender: (label) => {return 'Add "{label}"?'.replace('{label}', label)},
 			allowCreate: false,
 			asyncOptions: undefined,
 			autoload: true,
@@ -747,7 +747,7 @@ var Select = React.createClass({
 				mouseDown: this.selectValue,
 				mouseEnter: this.focusOption,
 				mouseLeave: this.unfocusOption,
-				addLabelText: this.props.addLabelText,
+				addLabelRender: this.props.addLabelRender,
 				option: op,
 				ref: ref
 			});


### PR DESCRIPTION
allows non-text element as the "add option" message.  This will let us render a better message that will hopefully be more noticeable / less confusing.

@mikemintz @elementsean @brian-element